### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/standards.yml
+++ b/.github/workflows/standards.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   standards:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/verifiedit/clicksend/security/code-scanning/2](https://github.com/verifiedit/clicksend/security/code-scanning/2)

In general, to fix this problem you should explicitly add a `permissions` block that grants only the minimal scopes needed by the workflow or job. For simple CI workflows that only check out code and run tests or linters, this is usually `contents: read` at the workflow or job level. If a job later needs to write to issues, pull requests, or contents, you would add the specific `: write` scopes required, instead of relying on broad defaults.

For this specific workflow, the `standards` job only checks out the repository, sets up PHP, installs dependencies via Composer, and runs a code-standards command. None of these operations require write access to the repository or other GitHub resources. The safest, least-intrusive fix is to add a `permissions` block scoped to this job (`jobs.standards.permissions`) and set `contents: read`. This keeps the change localized, avoids affecting other potential jobs in the same workflow file, and does not alter the functional behavior of any existing steps. The new block should be inserted directly under the `runs-on: ubuntu-latest` line (line 9) with correct YAML indentation.

No additional imports, methods, or definitions are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
