### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/verifiedit/clicksend/security/code-scanning/1](https://github.com/verifiedit/clicksend/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block limiting the `GITHUB_TOKEN` to only what this workflow needs. This can be done at the root level (affecting all jobs) or inside the specific job. Since this workflow contains a single `tests` job, either approach works; using a root-level `permissions` block is simpler and clearly documents the intent for the whole workflow.

The single best fix here is to add a minimal `permissions` block at the top level of `.github/workflows/tests.yml`, just under the `name:` (or just above `jobs:`). The job only checks out code, sets up PHP, installs dependencies, and runs tests. None of these steps require write access to the repo, nor special scopes like `pull-requests: write`. Therefore, `permissions: contents: read` is sufficient and recommended as a minimal starting point.

Concretely, in `.github/workflows/tests.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (or immediately after `name:` — both are valid; I’ll place it between `on:` and `jobs:` to keep event and permission configuration together). No imports or additional definitions are needed, as this is standard GitHub Actions YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
