### PR TITLE
Update CHANGELOG for v2.4.0: Laravel 13 and PHP 8.5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `clicksend` will be documented in this file.
 
+## 2.4.0
+**Released:** Mar 24, 2026
+
+- Added support for Laravel 13
+- Added tests for PHP 8.5
+- Check standards for PHP 8.5 and Laravel 13
+- Added this fancy changelog 
+
 ## 2.3.0
 **Released:** Mar 3, 2025
 


### PR DESCRIPTION
This pull request updates the `CHANGELOG.md` file to document the release of version 2.4.0. The changelog now includes new support for Laravel 13 and PHP 8.5, as well as the addition of this changelog section itself.

Release documentation updates:

* Added a new section for version 2.4.0, including release date and details of changes.
* Noted added support for Laravel 13 and PHP 8.5, including new tests and standards checks for these versions.
* Introduced the changelog file as part of the documented changes.