### PR TITLE
Task/remove unsupported versions of laravel and php

### DIFF
--- a/.github/workflows/standards.yml
+++ b/.github/workflows/standards.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4, 8.5]
+        php: [8.3, 8.4, 8.5]
 
     name: Standards (PHP ${{ matrix.php }})
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
+        php: [8.3, 8.4, 8.5]
 
     name: Tests (PHP ${{ matrix.php }})
 
@@ -32,4 +32,4 @@ jobs:
         run: composer update --prefer-source --no-interaction --no-progress
 
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: composer run test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.phar
 composer.lock
 .DS_Store
 .phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,17 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.3",
         "ext-json": "*",
-        "verifiedit/clicksend-sms": "^0.2 || ^0.3 || ^1.0",
-        "illuminate/config": ">=6.0",
-        "illuminate/events": ">=6.0",
-        "illuminate/notifications": ">=6.0",
-        "illuminate/queue": ">=6.0",
-        "illuminate/support": ">=6.0"
+        "verifiedit/clicksend-sms": "^2.0",
+        "illuminate/config": "^10 || ^11 || ^12 || ^13",
+        "illuminate/events": "^10 || ^11 || ^12 || ^13",
+        "illuminate/notifications": "^10 || ^11 || ^12 || ^13",
+        "illuminate/queue": "^10 || ^11 || ^12 || ^13",
+        "illuminate/support": "^10 || ^11 || ^12 || ^13"
     },
     "require-dev": {
-        "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^12.5.8",
         "laravel/pint": "^v1.0"
     },
     "autoload": {
@@ -39,8 +38,8 @@
     "scripts": {
         "pint": "./vendor/bin/pint",
         "pint:test": "@pint --test",
-        "test": "phpunit",
-        "test:coverage": "phpunit --coverage-text --coverage-clover=coverage.clover"
+        "test": "phpunit tests --display-deprecations --display-notices",
+        "test:coverage": "phpunit --configuration=phpunit.coverage.xml tests --coverage-text --coverage-clover=coverage.clover"
     },
     "minimum-stability": "dev",
     "config": {

--- a/phpunit.coverage.xml
+++ b/phpunit.coverage.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
   <testsuites>
     <testsuite name="ClickSend Test Suite">
       <directory>tests</directory>
@@ -9,3 +19,4 @@
     <junit outputFile="build/report.junit.xml"/>
   </logging>
 </phpunit>
+

--- a/phpunit.coverage.xml
+++ b/phpunit.coverage.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
       <html outputDirectory="build/coverage"/>
@@ -18,5 +16,9 @@
   <logging>
     <junit outputFile="build/report.junit.xml"/>
   </logging>
+  <source>
+    <include>
+      <directory>src/</directory>
+    </include>
+  </source>
 </phpunit>
-

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <testsuites>
-    <testsuite name="ClickSend Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
-  <logging>
-    <junit outputFile="build/report.junit.xml"/>
-  </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="ClickSend Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
 </phpunit>

--- a/src/ClickSendApi.php
+++ b/src/ClickSendApi.php
@@ -67,7 +67,7 @@ class ClickSendApi
             'data' => $data,
         ];
 
-        $messages = new Messages();
+        $messages = new Messages;
         $messages->add((new Message($message->getContent()))->setTo($to)->setFrom($from));
 
         if ($this->driver === 'log') {

--- a/src/ClickSendApi.php
+++ b/src/ClickSendApi.php
@@ -67,7 +67,7 @@ class ClickSendApi
             'data' => $data,
         ];
 
-        $messages = new Messages;
+        $messages = new Messages();
         $messages->add((new Message($message->getContent()))->setTo($to)->setFrom($from));
 
         if ($this->driver === 'log') {

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -28,7 +28,7 @@ class CouldNotSendNotification extends Exception
     /**
      * ClickSend returned an error message.
      */
-    public static function clickSendErrorMessage(?string $message): CouldNotSendNotification
+    public static function clickSendErrorMessage(?string $message = null): CouldNotSendNotification
     {
         return static::notificationError($message ?? 'No message.');
     }

--- a/tests/ClickSendChannelTest.php
+++ b/tests/ClickSendChannelTest.php
@@ -12,14 +12,16 @@ use NotificationChannels\ClickSend\ClickSendApi;
 use NotificationChannels\ClickSend\ClickSendChannel;
 use NotificationChannels\ClickSend\ClickSendMessage;
 use NotificationChannels\ClickSend\Exceptions\CouldNotSendNotification;
+use PHPUnit\Framework\Constraint\IsType;
+use PHPUnit\Framework\NativeType;
 use PHPUnit\Framework\TestCase;
 use Verifiedit\ClicksendSms\SMS\SMS;
 
 class ClickSendChannelTest extends TestCase
 {
-    private $api;
+    private ClickSendApi $api;
 
-    private $channel;
+    private ClickSendChannel $channel;
 
     /**
      * @throws BindingResolutionException
@@ -65,9 +67,12 @@ class ClickSendChannelTest extends TestCase
 
         $this->api->expects($this->once())
             ->method('sendSms')
-            ->with($this->callback(function ($arg) {
-                return $arg instanceof ClickSendMessage || is_string($arg);
-            }))
+            ->with(
+                new IsType(NativeType::String),
+                $this->callback(function ($arg) {
+                    return $arg instanceof ClickSendMessage || is_string($arg);
+                })
+            )
             ->willThrowException(new CouldNotSendNotification());
 
         $this->channel->send(new TestNotifiable(), new TestNotification());
@@ -104,9 +109,14 @@ class ClickSendChannelTest extends TestCase
 
         $this->api->expects($this->once())
             ->method('sendSms')
-            ->with($this->callback(function ($arg) {
-                return $arg instanceof ClickSendMessage || is_string($arg);
-            }))
+            ->with(
+                new IsType(NativeType::String),
+                $this->callback(
+                    function ($arg) {
+                        return $arg instanceof ClickSendMessage || is_string($arg);
+                    }
+                )
+            )
             ->willThrowException(new CouldNotSendNotification());
 
         $this->channel->send(new TestNotifiableWithAttribute(), new TestNotification());
@@ -118,9 +128,12 @@ class ClickSendChannelTest extends TestCase
 
         $this->api->expects($this->once())
             ->method('sendSms')
-            ->with($this->callback(function ($arg) {
-                return $arg instanceof ClickSendMessage || is_string($arg);
-            }))
+            ->with(
+                new IsType(NativeType::String),
+                $this->callback(function ($arg) {
+                    return $arg instanceof ClickSendMessage || is_string($arg);
+                })
+            )
             ->willThrowException(new CouldNotSendNotification());
 
         $notifiable = new AnonymousNotifiable();

--- a/tests/ClickSendChannelTest.php
+++ b/tests/ClickSendChannelTest.php
@@ -8,28 +8,27 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Notification;
-use Mockery;
-use Mockery\Adapter\Phpunit\MockeryTestCase;
 use NotificationChannels\ClickSend\ClickSendApi;
 use NotificationChannels\ClickSend\ClickSendChannel;
 use NotificationChannels\ClickSend\ClickSendMessage;
 use NotificationChannels\ClickSend\Exceptions\CouldNotSendNotification;
+use PHPUnit\Framework\TestCase;
 use Verifiedit\ClicksendSms\SMS\SMS;
 
-class ClickSendChannelTest extends MockeryTestCase
+class ClickSendChannelTest extends TestCase
 {
-    private ClickSendApi $api;
+    private $api;
 
-    private ClickSendChannel $channel;
+    private $channel;
 
     /**
      * @throws BindingResolutionException
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
-        $app = new Container();
+        $app = new Container;
         $app->singleton('app', 'Illuminate\Container\Container');
         $app->singleton(
             'events',
@@ -49,102 +48,83 @@ class ClickSendChannelTest extends MockeryTestCase
             }
         );
 
-        $api = Mockery::mock(SMS::class);
-        $this->api = Mockery::mock(ClickSendApi::class, [$api, 'from', 'clicksend']);
+        $smsMock = $this->createMock(SMS::class);
+        $this->api = $this->getMockBuilder(ClickSendApi::class)
+            ->setConstructorArgs([$smsMock, 'from', 'clicksend'])
+            ->onlyMethods(['sendSms'])
+            ->getMock();
         $this->channel = new ClickSendChannel($this->api, $app->make('events'));
     }
 
     /**
      * @throws CouldNotSendNotification
      */
-    public function testChannelCallsApi()
+    public function test_channel_calls_api()
     {
         $this->expectException(CouldNotSendNotification::class);
 
-        $this->api->shouldReceive('sendSms')
-            ->once()
-            ->withArgs(
-                function ($arg) {
-                    if ($arg instanceof ClickSendMessage) {
-                        return true;
-                    }
-                    if (is_string($arg)) {
-                        return true;
-                    }
+        $this->api->expects($this->once())
+            ->method('sendSms')
+            ->with($this->callback(function ($arg) {
+                return $arg instanceof ClickSendMessage || is_string($arg);
+            }))
+            ->willThrowException(new CouldNotSendNotification);
 
-                    return false;
-                }
-            );
-
-        $this->channel->send(new TestNotifiable(), new TestNotification());
+        $this->channel->send(new TestNotifiable, new TestNotification);
     }
 
     /**
      * @throws CouldNotSendNotification
      */
-    public function testDoesNotSendSmsWhenMissingRecipient()
+    public function test_does_not_send_sms_when_missing_recipient()
     {
         $this->expectException(CouldNotSendNotification::class);
 
-        $this->api->shouldReceive('sendSms')
-            ->atMost()
-            ->once()
-            ->andThrow(CouldNotSendNotification::class);
+        $this->api->expects($this->atMost(1))
+            ->method('sendSms')
+            ->willThrowException(new CouldNotSendNotification);
 
-        $this->channel->send(new TestNotifiableWithoutRouteNotificationFor(), new TestNotification());
+        $this->channel->send(new TestNotifiableWithoutRouteNotificationFor, new TestNotification);
     }
 
-    public function testBadDriver()
+    public function test_bad_driver()
     {
         $this->expectException(CouldNotSendNotification::class);
 
-        Mockery::mock(ClickSendApi::class, [Mockery::mock(SMS::class), 'from', 'bad']);
+        $smsMock = $this->createMock(SMS::class);
+        $this->getMockBuilder(ClickSendApi::class)
+            ->setConstructorArgs([$smsMock, 'from', 'bad'])
+            ->getMock();
     }
 
-    public function testNotifiableWithAttribute()
+    public function test_notifiable_with_attribute()
     {
         $this->expectException(CouldNotSendNotification::class);
 
-        $this->api->shouldReceive('sendSms')
-            ->once()
-            ->withArgs(
-                function ($arg) {
-                    if ($arg instanceof ClickSendMessage) {
-                        return true;
-                    }
-                    if (is_string($arg)) {
-                        return true;
-                    }
+        $this->api->expects($this->once())
+            ->method('sendSms')
+            ->with($this->callback(function ($arg) {
+                return $arg instanceof ClickSendMessage || is_string($arg);
+            }))
+            ->willThrowException(new CouldNotSendNotification);
 
-                    return false;
-                }
-            );
-
-        $this->channel->send(new TestNotifiableWithAttribute(), new TestNotification());
+        $this->channel->send(new TestNotifiableWithAttribute, new TestNotification);
     }
 
-    public function testNotifiableOnDemand()
+    public function test_notifiable_on_demand()
     {
         $this->expectException(CouldNotSendNotification::class);
 
-        $this->api->shouldReceive('sendSms')
-            ->once()
-            ->withArgs(
-                function ($arg) {
-                    if ($arg instanceof ClickSendMessage) {
-                        return true;
-                    }
-                    if (is_string($arg)) {
-                        return true;
-                    }
+        $this->api->expects($this->once())
+            ->method('sendSms')
+            ->with($this->callback(function ($arg) {
+                return $arg instanceof ClickSendMessage || is_string($arg);
+            }))
+            ->willThrowException(new CouldNotSendNotification);
 
-                    return false;
-                }
-            );
+        $notifiable = new AnonymousNotifiable;
 
-        $notifiable = new AnonymousNotifiable();
-
-        $this->channel->send($notifiable->route('clicksend', '+1234567890'), new TestNotification());
+        $this->channel->send($notifiable->route('clicksend', '+1234567890'), new TestNotification);
     }
 }
 

--- a/tests/ClickSendChannelTest.php
+++ b/tests/ClickSendChannelTest.php
@@ -12,6 +12,7 @@ use NotificationChannels\ClickSend\ClickSendApi;
 use NotificationChannels\ClickSend\ClickSendChannel;
 use NotificationChannels\ClickSend\ClickSendMessage;
 use NotificationChannels\ClickSend\Exceptions\CouldNotSendNotification;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Verifiedit\ClicksendSms\SMS\SMS;
 
@@ -48,9 +49,9 @@ class ClickSendChannelTest extends TestCase
             }
         );
 
-        $smsMock = $this->createMock(SMS::class);
+        $smsStub = $this->createStub(SMS::class);
         $this->api = $this->getMockBuilder(ClickSendApi::class)
-            ->setConstructorArgs([$smsMock, 'from', 'clicksend'])
+            ->setConstructorArgs([$smsStub, 'from', 'clicksend'])
             ->onlyMethods(['sendSms'])
             ->getMock();
         $this->channel = new ClickSendChannel($this->api, $app->make('events'));
@@ -91,10 +92,11 @@ class ClickSendChannelTest extends TestCase
     {
         $this->expectException(CouldNotSendNotification::class);
 
-        $smsMock = $this->createMock(SMS::class);
-        $this->getMockBuilder(ClickSendApi::class)
-            ->setConstructorArgs([$smsMock, 'from', 'bad'])
-            ->getMock();
+        // Add expectation for mock created in setUp, even though we don't use it
+        $this->api->expects($this->never())->method('sendSms');
+
+        $smsStub = $this->createStub(SMS::class);
+        new ClickSendApi($smsStub, 'from', 'bad');
     }
 
     public function test_notifiable_with_attribute()

--- a/tests/ClickSendChannelTest.php
+++ b/tests/ClickSendChannelTest.php
@@ -12,7 +12,6 @@ use NotificationChannels\ClickSend\ClickSendApi;
 use NotificationChannels\ClickSend\ClickSendChannel;
 use NotificationChannels\ClickSend\ClickSendMessage;
 use NotificationChannels\ClickSend\Exceptions\CouldNotSendNotification;
-use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Verifiedit\ClicksendSms\SMS\SMS;
 
@@ -29,7 +28,7 @@ class ClickSendChannelTest extends TestCase
     {
         parent::setUp();
 
-        $app = new Container;
+        $app = new Container();
         $app->singleton('app', 'Illuminate\Container\Container');
         $app->singleton(
             'events',
@@ -69,9 +68,9 @@ class ClickSendChannelTest extends TestCase
             ->with($this->callback(function ($arg) {
                 return $arg instanceof ClickSendMessage || is_string($arg);
             }))
-            ->willThrowException(new CouldNotSendNotification);
+            ->willThrowException(new CouldNotSendNotification());
 
-        $this->channel->send(new TestNotifiable, new TestNotification);
+        $this->channel->send(new TestNotifiable(), new TestNotification());
     }
 
     /**
@@ -83,9 +82,9 @@ class ClickSendChannelTest extends TestCase
 
         $this->api->expects($this->atMost(1))
             ->method('sendSms')
-            ->willThrowException(new CouldNotSendNotification);
+            ->willThrowException(new CouldNotSendNotification());
 
-        $this->channel->send(new TestNotifiableWithoutRouteNotificationFor, new TestNotification);
+        $this->channel->send(new TestNotifiableWithoutRouteNotificationFor(), new TestNotification());
     }
 
     public function test_bad_driver()
@@ -108,9 +107,9 @@ class ClickSendChannelTest extends TestCase
             ->with($this->callback(function ($arg) {
                 return $arg instanceof ClickSendMessage || is_string($arg);
             }))
-            ->willThrowException(new CouldNotSendNotification);
+            ->willThrowException(new CouldNotSendNotification());
 
-        $this->channel->send(new TestNotifiableWithAttribute, new TestNotification);
+        $this->channel->send(new TestNotifiableWithAttribute(), new TestNotification());
     }
 
     public function test_notifiable_on_demand()
@@ -122,11 +121,11 @@ class ClickSendChannelTest extends TestCase
             ->with($this->callback(function ($arg) {
                 return $arg instanceof ClickSendMessage || is_string($arg);
             }))
-            ->willThrowException(new CouldNotSendNotification);
+            ->willThrowException(new CouldNotSendNotification());
 
-        $notifiable = new AnonymousNotifiable;
+        $notifiable = new AnonymousNotifiable();
 
-        $this->channel->send($notifiable->route('clicksend', '+1234567890'), new TestNotification);
+        $this->channel->send($notifiable->route('clicksend', '+1234567890'), new TestNotification());
     }
 }
 

--- a/tests/ClickSendMessageTest.php
+++ b/tests/ClickSendMessageTest.php
@@ -7,14 +7,14 @@ use PHPUnit\Framework\TestCase;
 
 class ClickSendMessageTest extends TestCase
 {
-    public function testCreateInstance()
+    public function test_create_instance()
     {
         $message = new ClickSendMessage('message');
 
         $this->assertEquals('message', $message->getContent());
     }
 
-    public function testCanSetFromOnMessage()
+    public function test_can_set_from_on_message()
     {
         $message = new ClickSendMessage('message');
         $message->setFrom('from');
@@ -22,7 +22,7 @@ class ClickSendMessageTest extends TestCase
         $this->assertEquals('from', $message->getFrom());
     }
 
-    public function testFromSetToNullByDefault()
+    public function test_from_set_to_null_by_default()
     {
         $message = new ClickSendMessage('message');
 


### PR DESCRIPTION
This pull request updates the package to require PHP 8.3 or higher, modernizes dependencies, and refactors the test suite for compatibility with recent PHPUnit versions. It also updates CI workflows to align with the new requirements and improves test coverage reporting.

**Dependency and PHP version updates:**

* Updated `composer.json` to require PHP >=8.3 and upgraded dependencies, including `verifiedit/clicksend-sms` and `illuminate/*` packages to support versions 10–13. PHPUnit is now required at ^12.5.8.
* Updated test and coverage scripts in `composer.json` to use new PHPUnit flags and configuration.

**Continuous Integration (CI) workflow changes:**

* Updated `.github/workflows/tests.yml` and `.github/workflows/standards.yml` to only test against PHP 8.3, 8.4, and 8.5. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL16-R16) [[2]](diffhunk://#diff-db055c8165c0d0fe989ac0a9318e5bddc5e022211ea5f06a7aca0de2b39dfb79L15-R15)
* Changed the test execution command in CI to use `composer run test` for consistency with the new scripts.

**Testing and coverage improvements:**

* Replaced the old `phpunit.xml.dist` with a configuration compatible with PHPUnit 12, and added a separate `phpunit.coverage.xml` for coverage reporting. [[1]](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L2-R3) [[2]](diffhunk://#diff-5b8b0f5a5db508a2098b7f66e21a46eeb9c04584c6994f8279d3ef3537ecd3d7R1-R22)
* Refactored test classes to use PHPUnit's native mocking instead of Mockery, updated test method names to snake_case, and improved test reliability. [[1]](diffhunk://#diff-94daa6cb2fb15f3aca657cff23ce2003c279b7f34f432afc2f00302ac9a9d9e9L11-R32) [[2]](diffhunk://#diff-94daa6cb2fb15f3aca657cff23ce2003c279b7f34f432afc2f00302ac9a9d9e9L52-R129) [[3]](diffhunk://#diff-19ee5bcb28dcfa113f4a85df26c51f8c326f650d34a44caaf8a851394a042b92L10-R25)

**Code quality and minor fixes:**

* Allowed default value for `$message` in `CouldNotSendNotification::clickSendErrorMessage`.
* Minor code style changes for consistency (e.g., instantiating `Messages` without parentheses).