### PR TITLE
Update CHANGELOG for v3.0.0: remove support for Laravel 9 and below, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to `clicksend` will be documented in this file.
 ## 3.0.0
 **Released:** Apr 7, 2026
 
-- Remove support for Laravel 9 and below
-- Remove support for PHP 8.2 and below
+- Removed support for Laravel 9 and below
+- Removed support for PHP 8.2 and below
 
 ## 2.4.0
 **Released:** Mar 24, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `clicksend` will be documented in this file.
 
+## 3.0.0
+**Released:** Apr 7, 2026
+
+- Remove support for Laravel 9 and below
+- Remove support for PHP 8.2 and below
+
 ## 2.4.0
 **Released:** Mar 24, 2026
 


### PR DESCRIPTION
…PHP 8.2 and below

This pull request updates the `CHANGELOG.md` file to document the release of version 3.0.0, highlighting the removal of support for older versions of Laravel and PHP.

Release documentation:

* Added a changelog entry for version 3.0.0, noting the removal of support for Laravel 9 and below, and PHP 8.2 and below.